### PR TITLE
Change parameters argument to minkParameters to support autowiring

### DIFF
--- a/src/Element/Element.php
+++ b/src/Element/Element.php
@@ -23,11 +23,11 @@ abstract class Element
     private $document;
 
     /**
-     * @param array|\ArrayAccess $parameters
+     * @param array|\ArrayAccess $minkParameters
      */
-    public function __construct(Session $session, $parameters = [])
+    public function __construct(Session $session, $minkParameters = [])
     {
-        if (!is_array($parameters) && !$parameters instanceof \ArrayAccess) {
+        if (!is_array($minkParameters) && !$minkParameters instanceof \ArrayAccess) {
             throw new \InvalidArgumentException(sprintf(
                 '"$parameters" passed to "%s" has to be an array or implement "%s".',
                 self::class,
@@ -36,7 +36,7 @@ abstract class Element
         }
 
         $this->session = $session;
-        $this->parameters = $parameters;
+        $this->parameters = $minkParameters;
     }
 
     protected function getParameter(string $name): NodeElement

--- a/src/Page/Page.php
+++ b/src/Page/Page.php
@@ -24,11 +24,11 @@ abstract class Page implements PageInterface
     private $document;
 
     /**
-     * @param array|\ArrayAccess $parameters
+     * @param array|\ArrayAccess $minkParameters
      */
-    public function __construct(Session $session, $parameters = [])
+    public function __construct(Session $session, $minkParameters = [])
     {
-        if (!is_array($parameters) && !$parameters instanceof \ArrayAccess) {
+        if (!is_array($minkParameters) && !$minkParameters instanceof \ArrayAccess) {
             throw new \InvalidArgumentException(sprintf(
                 '"$parameters" passed to "%s" has to be an array or implement "%s".',
                 self::class,
@@ -37,7 +37,7 @@ abstract class Page implements PageInterface
         }
 
         $this->session = $session;
-        $this->parameters = $parameters;
+        $this->parameters = $minkParameters;
     }
 
     public function open(array $urlParameters = []): void

--- a/src/Page/SymfonyPage.php
+++ b/src/Page/SymfonyPage.php
@@ -16,11 +16,11 @@ abstract class SymfonyPage extends Page implements SymfonyPageInterface
     protected static $additionalParameters = ['_locale' => 'en_US'];
 
     /**
-     * @param array|\ArrayAccess $parameters
+     * @param array|\ArrayAccess $minkParameters
      */
-    public function __construct(Session $session, $parameters, RouterInterface $router)
+    public function __construct(Session $session, $minkParameters, RouterInterface $router)
     {
-        if (!is_array($parameters) && !$parameters instanceof \ArrayAccess) {
+        if (!is_array($minkParameters) && !$minkParameters instanceof \ArrayAccess) {
             throw new \InvalidArgumentException(sprintf(
                 '"$parameters" passed to "%s" has to be an array or implement "%s".',
                 self::class,
@@ -28,7 +28,7 @@ abstract class SymfonyPage extends Page implements SymfonyPageInterface
             ));
         }
 
-        parent::__construct($session, $parameters);
+        parent::__construct($session, $minkParameters);
 
         $this->router = $router;
     }


### PR DESCRIPTION
While autowiring Mink parameters with `$parameters` could be too much, we could setup autowiring for `$minkParameters` in SymfonyExtension.