### PR TITLE
Expand Element and SymfonyPage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,39 @@ Provides default classes for Page object pattern in Behat.
 This concept is extracted from [Sylius Behat system](https://github.com/Sylius/Sylius/tree/master/src/Sylius/Behat/Page) and
 inspired by [sensiolabs/BehatPageObjectExtension](https://github.com/sensiolabs/BehatPageObjectExtension/tree/master/src/PageObject)
 
-### Element
-
-`Element` represents part of the page. This concept is extracted from [SyliusAdminOrderCreation](https://github.com/Sylius/AdminOrderCreationPlugin/blob/master/tests/Behat/Element/Element.php).
-
 ### SymfonyPage
 
 `SymfonyPage` is an extension of `Page` class for better and more straightforward Symfony application support.
 This concept is also extracted from [Sylius Behat system](https://github.com/Sylius/Sylius/tree/master/src/Sylius/Behat/Page)
+
+### Element
+
+`Element` represents part of the page. This concept is extracted from [SyliusAdminOrderCreation](https://github.com/Sylius/AdminOrderCreationPlugin/blob/master/tests/Behat/Element/Element.php).
+
+When extending Element, specify the `$locator` property to specify the element on the page. 
+
+In the optional `$innerElements` array you can specify a named list of css locators of elements inside your element.
+
+```php
+class CategoryBar extends Element
+{
+    protected $locator = '#categoryBar';
+    
+    protected $innerElements = [
+        'items' => 'li:not(.more)',
+    ];
+
+    public function hasNumberOfCategories(int $numberOfCategories): bool
+    {
+        return $numberOfCategories === count($this->getElements('items'));
+    }
+
+    public function hasCategory(string $category): bool
+    {
+        return strpos($this->getText(), $category) !== false;
+    }
+}
+```
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     ],
     "require": {
         "php": "^7.1",
-
-        "behat/mink": "^1.7"
+        "behat/mink": "^1.7",
+        "friends-of-behat/symfony-extension": "^2.0"
     },
     "require-dev": {
         "symfony/routing": "^3.4"

--- a/src/Exception/InvalidElement.php
+++ b/src/Exception/InvalidElement.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace FriendsOfBehat\PageObjectExtension\Exception;
+
+use FriendsOfBehat\PageObjectExtension\Element\Element;
+
+final class InvalidElement extends \Exception
+{
+    public static function forName(string $className): self
+    {
+        return new self("Invalid Element class name given: '$className'.");
+    }
+
+    public static function forObject($element): self
+    {
+        return new self("Invalid Element object '" . get_class($element) . "'. Must implement " . Element::class);
+    }
+}


### PR DESCRIPTION
In this PR I put the changes we made to make it easier to work with Page and Element objects. Most notably the type hinting if the MinkParameters object. 
Personally, I'm not too happy about that, since it requires the complete `friends-of-behat/symfony-extension` dependency, but at this time there is no other way. I think it would be better if we could have the dependency work the other way around with an interface somehow.

This PR is still meant as a means to have a discussion, so I'm welcoming criticism. ;) It's easier to talk about something concrete.

Changes:

Expand the Element with helper methods and scoping of element search

Expand SymfonyPage
- Require an object in the constructor that can be auto wired by Symfony
- Add method to load our own Element objects instead of xpath Nodes
- Add additional url fix for symfony routes
