### PR TITLE
Expose node element

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,26 @@ inspired by [sensiolabs/BehatPageObjectExtension](https://github.com/sensiolabs/
 `SymfonyPage` is an extension of `Page` class for better and more straightforward Symfony application support.
 This concept is also extracted from [Sylius Behat system](https://github.com/Sylius/Sylius/tree/master/src/Sylius/Behat/Page)
 
+```php
+class NewsArticlePage extends SymfonyPage
+{
+    public function getRouteName(): string
+    {
+        return 'news.item';
+    }
+
+    public function hasComments(): bool
+    {
+        return $this->hasElement(Comments::class);
+    }
+
+    public function hasTitle(string $text): bool
+    {
+        return $this->getElementObject(Heading::class)->containsText($text);
+    }
+}
+```
+
 ### Element
 
 `Element` represents part of the page. This concept is extracted from [SyliusAdminOrderCreation](https://github.com/Sylius/AdminOrderCreationPlugin/blob/master/tests/Behat/Element/Element.php).

--- a/README.md
+++ b/README.md
@@ -8,14 +8,39 @@ Provides default classes for Page object pattern in Behat.
 This concept is extracted from [Sylius Behat system](https://github.com/Sylius/Sylius/tree/master/src/Sylius/Behat/Page) and
 inspired by [sensiolabs/BehatPageObjectExtension](https://github.com/sensiolabs/BehatPageObjectExtension/tree/master/src/PageObject)
 
-### Element
-
-`Element` represents part of the page. This concept is extracted from [SyliusAdminOrderCreation](https://github.com/Sylius/AdminOrderCreationPlugin/blob/master/tests/Behat/Element/Element.php).
-
 ### SymfonyPage
 
 `SymfonyPage` is an extension of `Page` class for better and more straightforward Symfony application support.
 This concept is also extracted from [Sylius Behat system](https://github.com/Sylius/Sylius/tree/master/src/Sylius/Behat/Page)
+
+### Element
+
+`Element` represents part of the page. This concept is extracted from [SyliusAdminOrderCreation](https://github.com/Sylius/AdminOrderCreationPlugin/blob/master/tests/Behat/Element/Element.php).
+
+When extending Element, specify the `$locator` property to specify the element on the page. 
+
+In the optional `$innerElements` array you can specify a named list of css locators of elements inside your element.
+
+```php
+class CategoryBar extends Element
+{
+    protected $locator = '#categoryBar';
+    
+    protected $innerElements = [
+        'items' => 'li:not(.more)',
+    ];
+
+    public function hasNumberOfCategories(int $numberOfCategories): bool
+    {
+        return $numberOfCategories === count($this->getElements('items'));
+    }
+
+    public function hasCategory(string $category): bool
+    {
+        return strpos($this->getText(), $category) !== false;
+    }
+}
+```
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     ],
     "require": {
         "php": "^7.1",
-
-        "behat/mink": "^1.7"
+        "behat/mink": "^1.7",
+        "friends-of-behat/symfony-extension": "^2.0"
     },
     "require-dev": {
         "symfony/routing": "^3.4"

--- a/src/Element/Element.php
+++ b/src/Element/Element.php
@@ -11,6 +11,54 @@ use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Selector\SelectorsHandler;
 use Behat\Mink\Session;
 
+/**
+ * @method NodeElement|null find
+ * @method NodeElement[] findAll
+ * @method NodeElement|null findById
+ * @method string getText
+ * @method string getHtml
+ * @method bool hasLink
+ * @method NodeElement|null findLink
+ * @method void clickLink
+ * @method bool hasButton
+ * @method NodeElement|null findButton
+ * @method void pressButton
+ * @method bool hasField
+ * @method NodeElement|null findField
+ * @method void fillField
+ * @method bool hasCheckedField
+ * @method bool hasUncheckedField
+ * @method void checkField
+ * @method void uncheckField
+ * @method bool hasSelect
+ * @method void selectFieldOption
+ * @method bool hasTable
+ * @method void attachFileToField
+ * @method string getTagName
+ * @method string|bool|array getValue
+ * @method bool hasAttribute
+ * @method string|null getAttribute
+ * @method bool hasClass
+ * @method void click
+ * @method void press
+ * @method void doubleClick
+ * @method void rightClick
+ * @method void check
+ * @method void uncheck
+ * @method bool isChecked
+ * @method void selectOption
+ * @method bool isSelected
+ * @method void attachFile
+ * @method bool isVisible
+ * @method void mouseOver
+ * @method void dragTo
+ * @method void focus
+ * @method void blur
+ * @method void keyPress
+ * @method void keyDown
+ * @method void keyUp
+ * @method void submit
+ */
 abstract class Element
 {
     /** @var Session */
@@ -62,72 +110,14 @@ abstract class Element
         return $this->locator;
     }
 
-    /**
-     * Finds first element with specified selector inside the current element.
-     *
-     * @param string       $selector selector engine name
-     * @param string|array $locator  selector locator
-     *
-     * @return NodeElement|null
-     *
-     * @see ElementInterface::findAll for the supported selectors
-     */
-    public function find($selector, $locator)
+    public function containsText(string $text): bool
     {
-        return $this->getElement($this->locator)->find($selector, $locator);
+        return strpos($this->getText(), $text) !== false;
     }
 
-    /**
-     * Finds all elements with specified selector inside the current element.
-     *
-     * Valid selector engines are named, xpath, css, named_partial and named_exact.
-     *
-     * 'named' is a pseudo selector engine which prefers an exact match but
-     * will return a partial match if no exact match is found.
-     * 'xpath' is a pseudo selector engine supported by SelectorsHandler.
-     *
-     * More selector engines can be registered in the SelectorsHandler.
-     *
-     * @param string       $selector selector engine name
-     * @param string|array $locator  selector locator
-     *
-     * @return NodeElement[]
-     *
-     * @see NamedSelector for the locators supported by the named selectors
-     */
-    public function findAll($selector, $locator)
+    public function __call($name, $params)
     {
-        return $this->getElement($this->locator)->findAll($selector, $locator);
-    }
-
-    /**
-     * Returns element text (inside tag).
-     *
-     * @return string
-     */
-    public function getText()
-    {
-        return $this->getElement($this->locator)->getText();
-    }
-
-    /**
-     * Returns element inner html.
-     *
-     * @return string
-     */
-    public function getHtml()
-    {
-        return $this->getElement($this->locator)->getHtml();
-    }
-
-    public function click(): void
-    {
-        $this->getElement($this->locator)->click();
-    }
-
-    public function fillField(string $locator, string $value)
-    {
-        $this->getElement($this->locator)->fillField($locator, $value);
+        return $this->getElement($this->locator)->$name(...$params);
     }
 
     protected function getParameter(string $name): NodeElement

--- a/src/Exception/InvalidElement.php
+++ b/src/Exception/InvalidElement.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace FriendsOfBehat\PageObjectExtension\Exception;
+
+use FriendsOfBehat\PageObjectExtension\Element\Element;
+
+final class InvalidElement extends \Exception
+{
+    public static function forName(string $className): self
+    {
+        return new self("Invalid Element class name given: '$className'.");
+    }
+
+    public static function forObject($element): self
+    {
+        return new self("Invalid Element object '" . get_class($element) . "'. Must implement " . Element::class);
+    }
+}


### PR DESCRIPTION
This PR is built on top of the other, so please only look at the last commit.

In this one I fully exposed the NodeElement methods. Again, I'm not sure if I like this much myself, but the `__call` is cleaner than copying all the methods into our Element. Why didn't you actually extend the NodeElement to start with?

I also added an example to the readme which is nice. 