### PR TITLE
Removes (Page|Element)::resolveParameters() string return type 

### DIFF
--- a/src/Element/Element.php
+++ b/src/Element/Element.php
@@ -120,7 +120,7 @@ abstract class Element
         return $selectorsHandler->selectorToXpath($selectorType, $locator);
     }
 
-    private function resolveParameters(string $name, array $parameters, array $definedElements): string
+    private function resolveParameters(string $name, array $parameters, array $definedElements)
     {
         if (!is_array($definedElements[$name])) {
             return strtr($definedElements[$name], $parameters);

--- a/src/Page/Page.php
+++ b/src/Page/Page.php
@@ -192,7 +192,7 @@ abstract class Page implements PageInterface
         return $selectorsHandler->selectorToXpath($selectorType, $locator);
     }
 
-    private function resolveParameters(string $name, array $parameters, array $definedElements): string
+    private function resolveParameters(string $name, array $parameters, array $definedElements)
     {
         if (!is_array($definedElements[$name])) {
             return strtr($definedElements[$name], $parameters);


### PR DESCRIPTION
resolveParameters() will return an array when your defined elements use an array rather than a string and therefore it cannot have its return type locked to only string. Mixed return types aren't due to arrive in PHP until v8. 