### PR TITLE
Modernise CI: Behat 4 + Symfony 8 matrix, PHPStan, CS Fixer, source cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,21 +15,42 @@ jobs:
     validate-composer:
         name: Validate composer.json
         runs-on: ubuntu-22.04
-        continue-on-error: false
         steps:
-            - name: Checkout
-              uses: actions/checkout@v3
-
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+            - uses: actions/checkout@v4
+            - uses: shivammathur/setup-php@v2
               with:
+                  php-version: '8.3'
                   coverage: none
-                  ini-values: "memory_limit=-1, zend.assertions=1"
-                  php-version: 8.3
                   tools: composer:v2
+            - run: composer validate --strict
 
-            - name: Validate composer.json
-              run: composer validate --strict
+    check-cs:
+        name: Coding standards
+        runs-on: ubuntu-22.04
+        steps:
+            - uses: actions/checkout@v4
+            - uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.3'
+                  coverage: none
+                  ini-values: "memory_limit=-1"
+                  tools: composer:v2
+            - run: composer install --prefer-dist --no-progress
+            - run: vendor/bin/php-cs-fixer check --diff
+
+    static-analysis:
+        name: Static analysis
+        runs-on: ubuntu-22.04
+        steps:
+            - uses: actions/checkout@v4
+            - uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '8.3'
+                  coverage: none
+                  ini-values: "memory_limit=-1"
+                  tools: composer:v2
+            - run: composer install --prefer-dist --no-progress
+            - run: vendor/bin/phpstan analyse
 
     check-syntax:
         name: PHP ${{ matrix.php-version }} syntax check
@@ -42,26 +63,18 @@ jobs:
                     - '8.4'
                     - '8.5'
         steps:
-            - name: Checkout
-              uses: actions/checkout@v3
-
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+            - uses: actions/checkout@v4
+            - uses: shivammathur/setup-php@v2
               with:
-                  coverage: none
-                  ini-values: "memory_limit=-1, zend.assertions=1"
                   php-version: ${{ matrix.php-version }}
+                  coverage: none
                   tools: composer:v2
-
-            - name: Install dependencies
-              run: composer install --prefer-dist --no-progress
-
-            - name: Check PHP syntax
-              run: find src -name "*.php" -print0 | xargs -0 -n1 php -l
+            - run: find src -name "*.php" -print0 | xargs -0 -n1 php -l
 
     test:
-        name: PHP ${{ matrix.php-version }} tests
+        name: PHP ${{ matrix.php-version }} / Symfony ${{ matrix.symfony-version }} / Behat ${{ matrix.behat-version }}
         runs-on: ubuntu-22.04
+        continue-on-error: ${{ matrix.experimental }}
         strategy:
             fail-fast: false
             matrix:
@@ -69,20 +82,33 @@ jobs:
                     - '8.3'
                     - '8.4'
                     - '8.5'
+                symfony-version: ['7.4']
+                behat-version: ['^3.31']
+                experimental: [false]
+                include:
+                    # Behat 4 + Symfony 7.4 (experimental until Behat 4 stable)
+                    - { php-version: '8.3', symfony-version: '7.4', behat-version: '4.x-dev', experimental: true }
+                    - { php-version: '8.4', symfony-version: '7.4', behat-version: '4.x-dev', experimental: true }
+                    - { php-version: '8.5', symfony-version: '7.4', behat-version: '4.x-dev', experimental: true }
+                    # Behat 4 + Symfony 8.0 (PHP 8.4+ only — Symfony 8 requires PHP 8.4)
+                    - { php-version: '8.4', symfony-version: '8.0', behat-version: '4.x-dev', experimental: true }
+                    - { php-version: '8.5', symfony-version: '8.0', behat-version: '4.x-dev', experimental: true }
+                    # Behat 4 + Symfony 8.1
+                    - { php-version: '8.4', symfony-version: '8.1', behat-version: '4.x-dev', experimental: true }
+                    - { php-version: '8.5', symfony-version: '8.1', behat-version: '4.x-dev', experimental: true }
         steps:
-            - name: Checkout
-              uses: actions/checkout@v3
-
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+            - uses: actions/checkout@v4
+            - uses: shivammathur/setup-php@v2
               with:
+                  php-version: ${{ matrix.php-version }}
                   coverage: none
                   ini-values: "memory_limit=-1, zend.assertions=1"
-                  php-version: ${{ matrix.php-version }}
                   tools: composer:v2
-
-            - name: Install dependencies
-              run: composer install --prefer-dist --no-progress
-
-            - name: Run tests
-              run: vendor/bin/behat --no-interaction
+            - name: Lock Symfony version
+              if: matrix.symfony-version != '7.4'
+              run: bin/lock-symfony-version.sh ${{ matrix.symfony-version }}
+            - name: Lock Behat version
+              if: matrix.behat-version != '^3.31'
+              run: bin/lock-behat-version.sh ${{ matrix.behat-version }}
+            - run: composer install --prefer-dist --no-progress
+            - run: vendor/bin/behat --no-interaction

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,3 +58,31 @@ jobs:
 
             - name: Check PHP syntax
               run: find src -name "*.php" -print0 | xargs -0 -n1 php -l
+
+    test:
+        name: PHP ${{ matrix.php-version }} tests
+        runs-on: ubuntu-22.04
+        strategy:
+            fail-fast: false
+            matrix:
+                php-version:
+                    - '8.3'
+                    - '8.4'
+                    - '8.5'
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  coverage: none
+                  ini-values: "memory_limit=-1, zend.assertions=1"
+                  php-version: ${{ matrix.php-version }}
+                  tools: composer:v2
+
+            - name: Install dependencies
+              run: composer install --prefer-dist --no-progress
+
+            - name: Run tests
+              run: vendor/bin/behat --no-interaction

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+name: Build
+
+on:
+    push:
+        branches:
+            - master
+    pull_request:
+    release:
+        types: [created]
+    schedule:
+        -
+            cron: "0 1 * * 6" # Run at 1am every Saturday
+
+jobs:
+    validate-composer:
+        name: Validate composer.json
+        runs-on: ubuntu-22.04
+        continue-on-error: false
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  coverage: none
+                  ini-values: "memory_limit=-1, zend.assertions=1"
+                  php-version: 8.3
+                  tools: composer:v2
+
+            - name: Validate composer.json
+              run: composer validate --strict
+
+    check-syntax:
+        name: PHP ${{ matrix.php-version }} syntax check
+        runs-on: ubuntu-22.04
+        strategy:
+            fail-fast: false
+            matrix:
+                php-version:
+                    - '8.3'
+                    - '8.4'
+                    - '8.5'
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  coverage: none
+                  ini-values: "memory_limit=-1, zend.assertions=1"
+                  php-version: ${{ matrix.php-version }}
+                  tools: composer:v2
+
+            - name: Install dependencies
+              run: composer install --prefer-dist --no-progress
+
+            - name: Check PHP syntax
+              run: find src -name "*.php" -print0 | xargs -0 -n1 php -l

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+$finder = Finder::create()
+    ->in([__DIR__ . '/src', __DIR__ . '/tests'])
+;
+
+return (new Config())
+    ->setRules([
+        '@Symfony' => true,
+        'phpdoc_to_comment' => ['ignored_tags' => ['psalm-suppress', 'phpstan-ignore']],
+    ])
+    ->setFinder($finder)
+;

--- a/behat.dist.php
+++ b/behat.dist.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Behat\Config\Config;
+use Behat\Config\Profile;
+use Behat\Config\Suite;
+
+if (!defined('BEHAT_BIN_PATH')) {
+    define('BEHAT_BIN_PATH', __DIR__ . '/vendor/bin/behat');
+}
+
+return (new Config())
+    ->withProfile(
+        (new Profile('default'))
+            ->withSuite(
+                (new Suite('default'))
+                    ->withPaths('features')
+                    ->withContexts(\Tests\FriendsOfBehat\PageObjectExtension\Behat\Context\TestContext::class)
+            )
+    );

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -1,0 +1,5 @@
+default:
+    suites:
+        default:
+            contexts:
+                - Tests\FriendsOfBehat\PageObjectExtension\Behat\Context\TestContext

--- a/bin/lock-behat-version.sh
+++ b/bin/lock-behat-version.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BEHAT_VERSION=$1
+
+jq --arg v "${BEHAT_VERSION}" '
+  .["require-dev"]["behat/behat"] = $v
+' < composer.json > composer.json.tmp && mv composer.json.tmp composer.json

--- a/bin/lock-symfony-version.sh
+++ b/bin/lock-symfony-version.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SYMFONY_VERSION=$1
+
+jq --arg v "~${SYMFONY_VERSION}.0" '
+  .["require-dev"] |= with_entries(.key as $k | if ($k | test("^symfony/")) then .value = $v else . end)
+' < composer.json > composer.json.tmp && mv composer.json.tmp composer.json

--- a/composer.json
+++ b/composer.json
@@ -25,13 +25,22 @@
         "behat/mink": "^1.9"
     },
     "require-dev": {
-        "symfony/routing": "^7.4"
+        "behat/behat": "^3.31",
+        "symfony/filesystem": "^7.4",
+        "symfony/process": "^7.4",
+        "symfony/yaml": "^7.4"
     },
     "suggest": {
         "symfony/routing": "Allow better support for PageObject pattern in Symfony applications"
     },
     "autoload": {
         "psr-4": { "FriendsOfBehat\\PageObjectExtension\\": "src/" }
+    },
+    "autoload-dev": {
+        "psr-4": { "Tests\\FriendsOfBehat\\PageObjectExtension\\": "tests/" }
+    },
+    "scripts": {
+        "test": "behat --no-interaction"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         {
             "name": "Kamil Kokot",
             "email": "kamil@kokot.me",
-            "homepage": "http://kamil.kokot.me"
+            "homepage": "https://kamilkokot.com"
         },
         {
             "name": "Mateusz Zalewski",
@@ -20,12 +20,12 @@
         }
     ],
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^8.3",
 
-        "behat/mink": "^1.7"
+        "behat/mink": "^1.9"
     },
     "require-dev": {
-        "symfony/routing": "^3.4 || ^4.4 || ^5.1"
+        "symfony/routing": "^7.4"
     },
     "suggest": {
         "symfony/routing": "Allow better support for PageObject pattern in Symfony applications"
@@ -38,7 +38,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.3-dev"
+            "dev-master": "0.4-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -25,14 +25,19 @@
         "behat/mink": "^1.9"
     },
     "require-dev": {
-        "behat/behat": "^3.31",
-        "symfony/filesystem": "^7.4",
-        "symfony/process": "^7.4",
-        "symfony/yaml": "^7.4"
+        "behat/behat": "^3.31 || 4.x-dev",
+        "friendsofphp/php-cs-fixer": "^3.75",
+        "phpstan/phpstan": "^2.0",
+        "symfony/filesystem": "^7.4 || ^8.0",
+        "symfony/process": "^7.4 || ^8.0",
+        "symfony/routing": "^7.4 || ^8.0",
+        "symfony/yaml": "^7.4 || ^8.0"
     },
     "suggest": {
         "symfony/routing": "Allow better support for PageObject pattern in Symfony applications"
     },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "psr-4": { "FriendsOfBehat\\PageObjectExtension\\": "src/" }
     },
@@ -40,7 +45,10 @@
         "psr-4": { "Tests\\FriendsOfBehat\\PageObjectExtension\\": "tests/" }
     },
     "scripts": {
-        "test": "behat --no-interaction"
+        "test": "behat --no-interaction",
+        "cs": "php-cs-fixer check --diff",
+        "cs-fix": "php-cs-fixer fix",
+        "stan": "phpstan analyse"
     },
     "config": {
         "sort-packages": true

--- a/features/element/getting_defined_elements.feature
+++ b/features/element/getting_defined_elements.feature
@@ -1,0 +1,136 @@
+Feature: Getting defined elements from a page
+
+    Background:
+        Given a standard autoloader configured
+        And a fake Mink driver available
+        And a Behat configuration containing:
+        """
+        default:
+            suites:
+                default:
+                    contexts:
+                        - App\Tests\SomeContext
+        """
+
+    Scenario: Getting an element that exists returns a NodeElement
+        And a feature file containing:
+        """
+        Feature:
+            Scenario:
+                Then I should be able to find the heading element
+        """
+        And a page file "tests/SomePage.php" containing:
+        """
+        <?php
+
+        namespace App\Tests;
+
+        use FriendsOfBehat\PageObjectExtension\Page\Page;
+        use Behat\Mink\Element\NodeElement;
+
+        final class SomePage extends Page {
+            protected function getUrl(array $urlParameters = []): string {
+                return 'http://localhost/';
+            }
+
+            protected function getDefinedElements(): array {
+                return [
+                    'heading' => 'h1',
+                    'paragraph' => 'p',
+                ];
+            }
+
+            public function hasHeading(): bool {
+                return $this->hasElement('heading');
+            }
+        }
+        """
+        And a context file "tests/SomeContext.php" containing:
+        """
+        <?php
+
+        namespace App\Tests;
+
+        use Behat\Behat\Context\Context;
+        use Behat\Mink\Session;
+
+        final class SomeContext implements Context {
+            private SomePage $page;
+
+            public function __construct() {
+                $session = new Session(new FakeDriver(['/' => '<html><body><h1>Hello</h1><p>World</p></body></html>']));
+                $session->start();
+                $this->page = new SomePage($session);
+            }
+
+            /** @Then I should be able to find the heading element */
+            public function shouldFindHeadingElement(): void {
+                $this->page->open();
+                assert($this->page->hasHeading() === true, 'Expected heading element to be found');
+            }
+        }
+        """
+        When I run Behat
+        Then it should pass
+
+    Scenario: Accessing an element that is not defined throws an exception
+        And a feature file containing:
+        """
+        Feature:
+            Scenario:
+                Then accessing an undefined element should fail with a clear message
+        """
+        And a page file "tests/SomePage.php" containing:
+        """
+        <?php
+
+        namespace App\Tests;
+
+        use FriendsOfBehat\PageObjectExtension\Page\Page;
+
+        final class SomePage extends Page {
+            protected function getUrl(array $urlParameters = []): string {
+                return 'http://localhost/';
+            }
+
+            protected function getDefinedElements(): array {
+                return ['heading' => 'h1'];
+            }
+
+            public function findUndefinedElement(): void {
+                $this->getElement('footer');
+            }
+        }
+        """
+        And a context file "tests/SomeContext.php" containing:
+        """
+        <?php
+
+        namespace App\Tests;
+
+        use Behat\Behat\Context\Context;
+        use Behat\Mink\Session;
+
+        final class SomeContext implements Context {
+            private SomePage $page;
+
+            public function __construct() {
+                $session = new Session(new FakeDriver(['/' => '<html><body><h1>Hello</h1></body></html>']));
+                $session->start();
+                $this->page = new SomePage($session);
+            }
+
+            /** @Then accessing an undefined element should fail with a clear message */
+            public function accessingUndefinedElementShouldThrow(): void {
+                $this->page->open();
+                try {
+                    $this->page->findUndefinedElement();
+                    throw new \RuntimeException('Expected InvalidArgumentException was not thrown');
+                } catch (\InvalidArgumentException $e) {
+                    assert(false !== strpos($e->getMessage(), 'footer'), 'Expected error to mention element name');
+                }
+            }
+        }
+        """
+        When I run Behat
+        Then it should pass

--- a/features/page/checking_if_page_is_open.feature
+++ b/features/page/checking_if_page_is_open.feature
@@ -1,0 +1,96 @@
+Feature: Checking if a page is open
+
+    Background:
+        Given a standard autoloader configured
+        And a fake Mink driver available
+        And a Behat configuration containing:
+        """
+        default:
+            suites:
+                default:
+                    contexts:
+                        - App\Tests\SomeContext
+        """
+        And a page file "tests/Homepage.php" containing:
+        """
+        <?php
+
+        namespace App\Tests;
+
+        use FriendsOfBehat\PageObjectExtension\Page\Page;
+
+        final class Homepage extends Page {
+            protected function getUrl(array $urlParameters = []): string {
+                return 'http://localhost/';
+            }
+        }
+        """
+
+    Scenario: isOpen returns true when on the correct page
+        And a feature file containing:
+        """
+        Feature:
+            Scenario:
+                Then the homepage should be open after opening it
+        """
+        And a context file "tests/SomeContext.php" containing:
+        """
+        <?php
+
+        namespace App\Tests;
+
+        use Behat\Behat\Context\Context;
+        use Behat\Mink\Session;
+
+        final class SomeContext implements Context {
+            private Homepage $page;
+
+            public function __construct() {
+                $session = new Session(new FakeDriver(['/' => '<html><body>Home</body></html>']));
+                $session->start();
+                $this->page = new Homepage($session);
+            }
+
+            /** @Then the homepage should be open after opening it */
+            public function homepageShouldBeOpen(): void {
+                $this->page->open();
+                assert($this->page->isOpen() === true, 'Expected page to be open');
+            }
+        }
+        """
+        When I run Behat
+        Then it should pass
+
+    Scenario: isOpen returns false when on a different page
+        And a feature file containing:
+        """
+        Feature:
+            Scenario:
+                Then the homepage should not be open before navigating to it
+        """
+        And a context file "tests/SomeContext.php" containing:
+        """
+        <?php
+
+        namespace App\Tests;
+
+        use Behat\Behat\Context\Context;
+        use Behat\Mink\Session;
+
+        final class SomeContext implements Context {
+            private Homepage $page;
+
+            public function __construct() {
+                $session = new Session(new FakeDriver(['/' => '<html><body>Home</body></html>', '/other' => '<html><body>Other</body></html>']));
+                $session->start();
+                $this->page = new Homepage($session);
+            }
+
+            /** @Then the homepage should not be open before navigating to it */
+            public function homepageShouldNotBeOpenInitially(): void {
+                assert($this->page->isOpen() === false, 'Expected page to not be open yet');
+            }
+        }
+        """
+        When I run Behat
+        Then it should pass

--- a/features/page/opening_a_page.feature
+++ b/features/page/opening_a_page.feature
@@ -1,0 +1,104 @@
+Feature: Opening a page
+
+    Background:
+        Given a standard autoloader configured
+        And a fake Mink driver available
+        And a Behat configuration containing:
+        """
+        default:
+            suites:
+                default:
+                    contexts:
+                        - App\Tests\SomeContext
+        """
+
+    Scenario: Opening a page navigates to the correct URL and content is readable
+        And a feature file containing:
+        """
+        Feature:
+            Scenario:
+                When I open the homepage
+                Then I should see "Welcome to the homepage"
+        """
+        And a context file "tests/SomeContext.php" containing:
+        """
+        <?php
+
+        namespace App\Tests;
+
+        use Behat\Behat\Context\Context;
+        use Behat\Mink\Session;
+
+        final class SomeContext implements Context {
+            private Homepage $page;
+
+            public function __construct() {
+                $session = new Session(new FakeDriver(['/' => '<html><body><h1>Welcome to the homepage</h1></body></html>']));
+                $session->start();
+                $this->page = new Homepage($session);
+            }
+
+            /** @When I open the homepage */
+            public function openHomepage(): void {
+                $this->page->open();
+            }
+
+            /** @Then I should see :text */
+            public function shouldSee(string $text): void {
+                assert(false !== strpos($this->page->getContent(), $text), 'Text not found: ' . $text);
+            }
+        }
+
+        final class Homepage extends \FriendsOfBehat\PageObjectExtension\Page\Page {
+            public function getContent(): string {
+                return $this->getDocument()->getContent();
+            }
+
+            protected function getUrl(array $urlParameters = []): string {
+                return 'http://localhost/';
+            }
+        }
+        """
+        When I run Behat
+        Then it should pass
+
+    Scenario: Opening a page that returns an error status code raises an exception
+        And a feature file containing:
+        """
+        Feature:
+            Scenario:
+                When I try to open a missing page
+        """
+        And a context file "tests/SomeContext.php" containing:
+        """
+        <?php
+
+        namespace App\Tests;
+
+        use Behat\Behat\Context\Context;
+        use Behat\Mink\Session;
+        use FriendsOfBehat\PageObjectExtension\Page\UnexpectedPageException;
+
+        final class SomeContext implements Context {
+            private NotFoundPage $page;
+
+            public function __construct() {
+                $session = new Session(new FakeDriver(['/' => '<html><body>Home</body></html>']));
+                $session->start();
+                $this->page = new NotFoundPage($session);
+            }
+
+            /** @When I try to open a missing page */
+            public function openMissingPage(): void {
+                $this->page->open();
+            }
+        }
+
+        final class NotFoundPage extends \FriendsOfBehat\PageObjectExtension\Page\Page {
+            protected function getUrl(array $urlParameters = []): string {
+                return 'http://localhost/this-page-does-not-exist';
+            }
+        }
+        """
+        When I run Behat
+        Then it should fail with "UnexpectedPageException"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,271 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Element\\Element\:\:__construct\(\) has parameter \$minkParameters with generic interface ArrayAccess but does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: src/Element/Element.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Element\\Element\:\:__construct\(\) has parameter \$minkParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Element/Element.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Element\\Element\:\:createElement\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Element/Element.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Element\\Element\:\:getDefinedElements\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Element/Element.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Element\\Element\:\:getElement\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Element/Element.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Element\\Element\:\:getSelectorAsXpath\(\) has parameter \$selector with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Element/Element.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Element\\Element\:\:hasElement\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Element/Element.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Element\\Element\:\:resolveParameters\(\) has parameter \$definedElements with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Element/Element.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Element\\Element\:\:resolveParameters\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Element/Element.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Element\\Element\:\:resolveParameters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Element/Element.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\Page\:\:__construct\(\) has parameter \$minkParameters with generic interface ArrayAccess but does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: src/Page/Page.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\Page\:\:__construct\(\) has parameter \$minkParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/Page.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\Page\:\:createElement\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/Page.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\Page\:\:getDefinedElements\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/Page.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\Page\:\:getElement\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/Page.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\Page\:\:getSelectorAsXpath\(\) has parameter \$selector with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/Page.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\Page\:\:getUrl\(\) has parameter \$urlParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/Page.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\Page\:\:hasElement\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/Page.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\Page\:\:isOpen\(\) has parameter \$urlParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/Page.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\Page\:\:open\(\) has parameter \$urlParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/Page.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\Page\:\:resolveParameters\(\) has parameter \$definedElements with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/Page.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\Page\:\:resolveParameters\(\) has parameter \$parameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/Page.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\Page\:\:resolveParameters\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/Page.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\Page\:\:tryToOpen\(\) has parameter \$urlParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/Page.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\Page\:\:verify\(\) has parameter \$urlParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/Page.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\Page\:\:verifyUrl\(\) has parameter \$urlParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/Page.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\PageInterface\:\:isOpen\(\) has parameter \$urlParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/PageInterface.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\PageInterface\:\:open\(\) has parameter \$urlParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/PageInterface.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\PageInterface\:\:tryToOpen\(\) has parameter \$urlParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/PageInterface.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\PageInterface\:\:verify\(\) has parameter \$urlParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/PageInterface.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\SymfonyPage\:\:__construct\(\) has parameter \$minkParameters with generic interface ArrayAccess but does not specify its types\: TKey, TValue$#'
+			identifier: missingType.generics
+			count: 1
+			path: src/Page/SymfonyPage.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\SymfonyPage\:\:__construct\(\) has parameter \$minkParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/SymfonyPage.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\SymfonyPage\:\:getUrl\(\) has parameter \$urlParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/SymfonyPage.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\SymfonyPage\:\:matchCurrentRoute\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/SymfonyPage.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\SymfonyPage\:\:verifyRoute\(\) has parameter \$requiredUrlParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/SymfonyPage.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\SymfonyPage\:\:verifyRouteName\(\) has parameter \$matchedRoute with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/SymfonyPage.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\SymfonyPage\:\:verifyRouteParameters\(\) has parameter \$matchedRoute with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/SymfonyPage.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\SymfonyPage\:\:verifyRouteParameters\(\) has parameter \$requiredUrlParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/SymfonyPage.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\SymfonyPage\:\:verifyUrl\(\) has parameter \$urlParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/SymfonyPage.php
+
+		-
+			message: '#^Parameter \#3 \$subject of function preg_replace expects array\<float\|int\|string\>\|string, string\|false given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/Page/SymfonyPage.php
+
+		-
+			message: '#^Property FriendsOfBehat\\PageObjectExtension\\Page\\SymfonyPage\:\:\$additionalParameters type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/SymfonyPage.php
+
+		-
+			message: '#^Method FriendsOfBehat\\PageObjectExtension\\Page\\SymfonyPageInterface\:\:verifyRoute\(\) has parameter \$requiredUrlParameters with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/Page/SymfonyPageInterface.php
+
+		-
+			message: '#^Method Tests\\FriendsOfBehat\\PageObjectExtension\\Behat\\Config\\ArrayConfig\:\:__construct\(\) has parameter \$data with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Behat/Config/ArrayConfig.php
+
+		-
+			message: '#^Method Tests\\FriendsOfBehat\\PageObjectExtension\\Behat\\Config\\ArrayConfig\:\:toArray\(\) return type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Behat/Config/ArrayConfig.php
+
+		-
+			message: '#^Property Tests\\FriendsOfBehat\\PageObjectExtension\\Behat\\Context\\TestContext\:\:\$mergedConfig type has no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: tests/Behat/Context/TestContext.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,11 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 8
+    paths:
+        - src
+        - tests
+    bootstrapFiles:
+        - phpstan/bootstrap.php
+    treatPhpDocTypesAsCertain: false

--- a/phpstan/bootstrap.php
+++ b/phpstan/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+define('BEHAT_BIN_PATH', '');

--- a/src/Element/Element.php
+++ b/src/Element/Element.php
@@ -13,35 +13,20 @@ use Behat\Mink\Session;
 
 abstract class Element
 {
-    /** @var Session */
-    private $session;
-
-    /** @var array */
-    private $parameters;
-
-    /** @var DocumentElement|null */
-    private $document;
+    private ?DocumentElement $document = null;
 
     /**
      * @param array|\ArrayAccess $minkParameters
      */
-    public function __construct(Session $session, $minkParameters = [])
-    {
-        if (!is_array($minkParameters) && !$minkParameters instanceof \ArrayAccess) {
-            throw new \InvalidArgumentException(sprintf(
-                '"$parameters" passed to "%s" has to be an array or implement "%s".',
-                self::class,
-                \ArrayAccess::class
-            ));
-        }
-
-        $this->session = $session;
-        $this->parameters = $minkParameters;
+    public function __construct(
+        private Session $session,
+        private array|\ArrayAccess $minkParameters = [],
+    ) {
     }
 
-    protected function getParameter(string $name)
+    protected function getParameter(string $name): mixed
     {
-        return $this->parameters[$name] ?? null;
+        return $this->minkParameters[$name] ?? null;
     }
 
     protected function getDefinedElements(): array
@@ -112,7 +97,7 @@ abstract class Element
         );
     }
 
-    private function getSelectorAsXpath($selector, SelectorsHandler $selectorsHandler): string
+    private function getSelectorAsXpath(string|array $selector, SelectorsHandler $selectorsHandler): string
     {
         $selectorType = is_array($selector) ? key($selector) : 'css';
         $locator = is_array($selector) ? $selector[$selectorType] : $selector;
@@ -120,14 +105,14 @@ abstract class Element
         return $selectorsHandler->selectorToXpath($selectorType, $locator);
     }
 
-    private function resolveParameters(string $name, array $parameters, array $definedElements): string
+    private function resolveParameters(string $name, array $parameters, array $definedElements): string|array
     {
         if (!is_array($definedElements[$name])) {
             return strtr($definedElements[$name], $parameters);
         }
 
         array_map(
-            function ($definedElement) use ($parameters): string {
+            static function ($definedElement) use ($parameters): string {
                 return strtr($definedElement, $parameters);
             }, $definedElements[$name]
         );

--- a/src/Element/Element.php
+++ b/src/Element/Element.php
@@ -15,9 +15,6 @@ abstract class Element
 {
     private ?DocumentElement $document = null;
 
-    /**
-     * @param array|\ArrayAccess $minkParameters
-     */
     public function __construct(
         private Session $session,
         private array|\ArrayAccess $minkParameters = [],
@@ -42,12 +39,7 @@ abstract class Element
         $element = $this->createElement($name, $parameters);
 
         if (!$this->getDocument()->has('xpath', $element->getXpath())) {
-            throw new ElementNotFoundException(
-                $this->getSession(),
-                sprintf('Element named "%s" with parameters %s', $name, implode(', ', $parameters)),
-                'xpath',
-                $element->getXpath()
-            );
+            throw new ElementNotFoundException($this->getSession(), sprintf('Element named "%s" with parameters %s', $name, implode(', ', $parameters)), 'xpath', $element->getXpath());
         }
 
         return $element;
@@ -82,11 +74,7 @@ abstract class Element
         $definedElements = $this->getDefinedElements();
 
         if (!isset($definedElements[$name])) {
-            throw new \InvalidArgumentException(sprintf(
-                'Could not find a defined element with name "%s". The defined ones are: %s.',
-                $name,
-                implode(', ', array_keys($definedElements))
-            ));
+            throw new \InvalidArgumentException(sprintf('Could not find a defined element with name "%s". The defined ones are: %s.', $name, implode(', ', array_keys($definedElements))));
         }
 
         $elementSelector = $this->resolveParameters($name, $parameters, $definedElements);
@@ -99,7 +87,7 @@ abstract class Element
 
     private function getSelectorAsXpath(string|array $selector, SelectorsHandler $selectorsHandler): string
     {
-        $selectorType = is_array($selector) ? key($selector) : 'css';
+        $selectorType = is_array($selector) ? (string) array_key_first($selector) : 'css';
         $locator = is_array($selector) ? $selector[$selectorType] : $selector;
 
         return $selectorsHandler->selectorToXpath($selectorType, $locator);
@@ -111,12 +99,6 @@ abstract class Element
             return strtr($definedElements[$name], $parameters);
         }
 
-        array_map(
-            static function ($definedElement) use ($parameters): string {
-                return strtr($definedElement, $parameters);
-            }, $definedElements[$name]
-        );
-
-        return $definedElements[$name];
+        return array_map(static fn ($locator) => strtr($locator, $parameters), $definedElements[$name]);
     }
 }

--- a/src/Page/Page.php
+++ b/src/Page/Page.php
@@ -16,9 +16,6 @@ abstract class Page implements PageInterface
 {
     private ?DocumentElement $document = null;
 
-    /**
-     * @param array|\ArrayAccess $minkParameters
-     */
     public function __construct(
         private Session $session,
         private array|\ArrayAccess $minkParameters = [],
@@ -46,7 +43,7 @@ abstract class Page implements PageInterface
     {
         try {
             $this->verify($urlParameters);
-        } catch (\Exception $exception) {
+        } catch (\Exception) {
             return false;
         }
 
@@ -62,7 +59,7 @@ abstract class Page implements PageInterface
     {
         try {
             $statusCode = $this->getSession()->getStatusCode();
-        } catch (DriverException $exception) {
+        } catch (DriverException) {
             return; // Ignore drivers which cannot check the response status code
         }
 
@@ -111,12 +108,7 @@ abstract class Page implements PageInterface
         $element = $this->createElement($name, $parameters);
 
         if (!$this->getDocument()->has('xpath', $element->getXpath())) {
-            throw new ElementNotFoundException(
-                $this->getSession(),
-                sprintf('Element named "%s" with parameters %s', $name, implode(', ', $parameters)),
-                'xpath',
-                $element->getXpath()
-            );
+            throw new ElementNotFoundException($this->getSession(), sprintf('Element named "%s" with parameters %s', $name, implode(', ', $parameters)), 'xpath', $element->getXpath());
         }
 
         return $element;
@@ -151,11 +143,7 @@ abstract class Page implements PageInterface
         $definedElements = $this->getDefinedElements();
 
         if (!isset($definedElements[$name])) {
-            throw new \InvalidArgumentException(sprintf(
-                'Could not find a defined element with name "%s". The defined ones are: %s.',
-                $name,
-                implode(', ', array_keys($definedElements))
-            ));
+            throw new \InvalidArgumentException(sprintf('Could not find a defined element with name "%s". The defined ones are: %s.', $name, implode(', ', array_keys($definedElements))));
         }
 
         $elementSelector = $this->resolveParameters($name, $parameters, $definedElements);
@@ -166,12 +154,9 @@ abstract class Page implements PageInterface
         );
     }
 
-    /**
-     * @param string|array $selector
-     */
     private function getSelectorAsXpath(string|array $selector, SelectorsHandler $selectorsHandler): string
     {
-        $selectorType = is_array($selector) ? key($selector) : 'css';
+        $selectorType = is_array($selector) ? (string) array_key_first($selector) : 'css';
         $locator = is_array($selector) ? $selector[$selectorType] : $selector;
 
         return $selectorsHandler->selectorToXpath($selectorType, $locator);
@@ -183,12 +168,6 @@ abstract class Page implements PageInterface
             return strtr($definedElements[$name], $parameters);
         }
 
-        array_map(
-            static function ($definedElement) use ($parameters) {
-                return strtr($definedElement, $parameters);
-            }, $definedElements[$name]
-        );
-
-        return $definedElements[$name];
+        return array_map(static fn ($locator) => strtr($locator, $parameters), $definedElements[$name]);
     }
 }

--- a/src/Page/Page.php
+++ b/src/Page/Page.php
@@ -14,30 +14,15 @@ use Behat\Mink\Session;
 
 abstract class Page implements PageInterface
 {
-    /** @var Session */
-    private $session;
-
-    /** @var array */
-    private $parameters;
-
-    /** @var DocumentElement|null */
-    private $document;
+    private ?DocumentElement $document = null;
 
     /**
      * @param array|\ArrayAccess $minkParameters
      */
-    public function __construct(Session $session, $minkParameters = [])
-    {
-        if (!is_array($minkParameters) && !$minkParameters instanceof \ArrayAccess) {
-            throw new \InvalidArgumentException(sprintf(
-                '"$parameters" passed to "%s" has to be an array or implement "%s".',
-                self::class,
-                \ArrayAccess::class
-            ));
-        }
-
-        $this->session = $session;
-        $this->parameters = $minkParameters;
+    public function __construct(
+        private Session $session,
+        private array|\ArrayAccess $minkParameters = [],
+    ) {
     }
 
     public function open(array $urlParameters = []): void
@@ -103,9 +88,9 @@ abstract class Page implements PageInterface
         }
     }
 
-    protected function getParameter(string $name): ?string
+    protected function getParameter(string $name): mixed
     {
-        return $this->parameters[$name] ?? null;
+        return $this->minkParameters[$name] ?? null;
     }
 
     /**
@@ -184,7 +169,7 @@ abstract class Page implements PageInterface
     /**
      * @param string|array $selector
      */
-    private function getSelectorAsXpath($selector, SelectorsHandler $selectorsHandler): string
+    private function getSelectorAsXpath(string|array $selector, SelectorsHandler $selectorsHandler): string
     {
         $selectorType = is_array($selector) ? key($selector) : 'css';
         $locator = is_array($selector) ? $selector[$selectorType] : $selector;
@@ -192,14 +177,14 @@ abstract class Page implements PageInterface
         return $selectorsHandler->selectorToXpath($selectorType, $locator);
     }
 
-    private function resolveParameters(string $name, array $parameters, array $definedElements): string
+    private function resolveParameters(string $name, array $parameters, array $definedElements): string|array
     {
         if (!is_array($definedElements[$name])) {
             return strtr($definedElements[$name], $parameters);
         }
 
         array_map(
-            function ($definedElement) use ($parameters) {
+            static function ($definedElement) use ($parameters) {
                 return strtr($definedElement, $parameters);
             }, $definedElements[$name]
         );

--- a/src/Page/PageInterface.php
+++ b/src/Page/PageInterface.php
@@ -11,7 +11,7 @@ interface PageInterface
      */
     public function open(array $urlParameters = []): void;
 
-    public function tryToOpen(array $urlParameters = []):void;
+    public function tryToOpen(array $urlParameters = []): void;
 
     /**
      * @throws UnexpectedPageException

--- a/src/Page/SymfonyPage.php
+++ b/src/Page/SymfonyPage.php
@@ -9,28 +9,15 @@ use Symfony\Component\Routing\RouterInterface;
 
 abstract class SymfonyPage extends Page implements SymfonyPageInterface
 {
-    /** @var RouterInterface */
-    protected $router;
-
     /** @var array */
-    protected static $additionalParameters = ['_locale' => 'en_US'];
+    protected static array $additionalParameters = ['_locale' => 'en_US'];
 
     /**
      * @param array|\ArrayAccess $minkParameters
      */
-    public function __construct(Session $session, $minkParameters, RouterInterface $router)
+    public function __construct(Session $session, array|\ArrayAccess $minkParameters, protected RouterInterface $router)
     {
-        if (!is_array($minkParameters) && !$minkParameters instanceof \ArrayAccess) {
-            throw new \InvalidArgumentException(sprintf(
-                '"$parameters" passed to "%s" has to be an array or implement "%s".',
-                self::class,
-                \ArrayAccess::class
-            ));
-        }
-
         parent::__construct($session, $minkParameters);
-
-        $this->router = $router;
     }
 
     abstract public function getRouteName(): string;
@@ -54,7 +41,7 @@ abstract class SymfonyPage extends Page implements SymfonyPageInterface
     {
         $baseUrl = rtrim($this->getParameter('base_url'), '/') . '/';
 
-        return 0 !== strpos($path, 'http') ? $baseUrl . ltrim($path, '/') : $path;
+        return !str_starts_with($path, 'http') ? $baseUrl . ltrim($path, '/') : $path;
     }
 
     protected function getUrl(array $urlParameters = []): string

--- a/src/Page/SymfonyPage.php
+++ b/src/Page/SymfonyPage.php
@@ -9,12 +9,8 @@ use Symfony\Component\Routing\RouterInterface;
 
 abstract class SymfonyPage extends Page implements SymfonyPageInterface
 {
-    /** @var array */
     protected static array $additionalParameters = ['_locale' => 'en_US'];
 
-    /**
-     * @param array|\ArrayAccess $minkParameters
-     */
     public function __construct(Session $session, array|\ArrayAccess $minkParameters, protected RouterInterface $router)
     {
         parent::__construct($session, $minkParameters);
@@ -27,21 +23,17 @@ abstract class SymfonyPage extends Page implements SymfonyPageInterface
      */
     public function verifyRoute(array $requiredUrlParameters = []): void
     {
-        $url = $this->getDriver()->getCurrentUrl();
-        $path = parse_url($url)['path'];
+        $matchedRoute = $this->matchCurrentRoute();
 
-        $path = preg_replace('#^/app(_dev|_test|_test_cached)?\.php/#', '/', $path);
-        $matchedRoute = $this->router->match($path);
-
-        $this->verifyRouteName($matchedRoute, $url);
+        $this->verifyRouteName($matchedRoute, $this->getDriver()->getCurrentUrl());
         $this->verifyRouteParameters($requiredUrlParameters, $matchedRoute);
     }
 
     final protected function makePathAbsolute(string $path): string
     {
-        $baseUrl = rtrim($this->getParameter('base_url'), '/') . '/';
+        $baseUrl = rtrim($this->getParameter('base_url'), '/').'/';
 
-        return !str_starts_with($path, 'http') ? $baseUrl . ltrim($path, '/') : $path;
+        return !str_starts_with($path, 'http') ? $baseUrl.ltrim($path, '/') : $path;
     }
 
     protected function getUrl(array $urlParameters = []): string
@@ -62,11 +54,7 @@ abstract class SymfonyPage extends Page implements SymfonyPageInterface
 
     protected function verifyUrl(array $urlParameters = []): void
     {
-        $url = $this->getDriver()->getCurrentUrl();
-        $path = parse_url($url)['path'];
-
-        $path = preg_replace('#^/app(_dev|_test|_test_cached)?\.php/#', '/', $path);
-        $matchedRoute = $this->router->match($path);
+        $matchedRoute = $this->matchCurrentRoute();
 
         if (isset($matchedRoute['_locale'])) {
             $urlParameters += ['_locale' => $matchedRoute['_locale']];
@@ -75,20 +63,22 @@ abstract class SymfonyPage extends Page implements SymfonyPageInterface
         parent::verifyUrl($urlParameters);
     }
 
+    private function matchCurrentRoute(): array
+    {
+        $path = parse_url($this->getDriver()->getCurrentUrl(), PHP_URL_PATH) ?? '/';
+
+        return $this->router->match(
+            (string) preg_replace('#^/app(_dev|_test|_test_cached)?\.php/#', '/', $path),
+        );
+    }
+
     /**
      * @throws UnexpectedPageException
      */
     private function verifyRouteName(array $matchedRoute, string $url): void
     {
         if ($matchedRoute['_route'] !== $this->getRouteName()) {
-            throw new UnexpectedPageException(
-                sprintf(
-                    "Matched route '%s' does not match the expected route '%s' for URL '%s'",
-                    $matchedRoute['_route'],
-                    $this->getRouteName(),
-                    $url
-                )
-            );
+            throw new UnexpectedPageException(sprintf("Matched route '%s' does not match the expected route '%s' for URL '%s'", $matchedRoute['_route'], $this->getRouteName(), $url));
         }
     }
 
@@ -99,14 +89,7 @@ abstract class SymfonyPage extends Page implements SymfonyPageInterface
     {
         foreach ($requiredUrlParameters as $key => $value) {
             if (!isset($matchedRoute[$key]) || $matchedRoute[$key] !== $value) {
-                throw new UnexpectedPageException(
-                    sprintf(
-                        "Matched route does not match the expected parameter '%s'='%s' (%s found)",
-                        $key,
-                        $value,
-                        $matchedRoute[$key] ?? 'null'
-                    )
-                );
+                throw new UnexpectedPageException(sprintf("Matched route does not match the expected parameter '%s'='%s' (%s found)", $key, $value, $matchedRoute[$key] ?? 'null'));
             }
         }
     }

--- a/tests/Behat/Config/ArrayConfig.php
+++ b/tests/Behat/Config/ArrayConfig.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FriendsOfBehat\PageObjectExtension\Behat\Config;
+
+use Behat\Config\ConfigInterface;
+
+final class ArrayConfig implements ConfigInterface
+{
+    public function __construct(private readonly array $data)
+    {
+    }
+
+    public function toArray(): array
+    {
+        return $this->data;
+    }
+}

--- a/tests/Behat/Context/TestContext.php
+++ b/tests/Behat/Context/TestContext.php
@@ -1,0 +1,353 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\FriendsOfBehat\PageObjectExtension\Behat\Context;
+
+use Behat\Behat\Context\Context;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Process\PhpExecutableFinder;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Yaml\Yaml;
+
+final class TestContext implements Context
+{
+    private static string $workingDir;
+
+    private static Filesystem $filesystem;
+
+    private static string $phpBin;
+
+    private ?Process $process = null;
+
+    private array $mergedConfig = [];
+
+    #[\Behat\Hook\BeforeFeature]
+    public static function beforeFeature(): void
+    {
+        self::$workingDir = sprintf('%s/%s/', sys_get_temp_dir(), uniqid('', true));
+        self::$filesystem = new Filesystem();
+        self::$phpBin = self::findPhpBinary();
+    }
+
+    #[\Behat\Hook\BeforeScenario]
+    public function beforeScenario(): void
+    {
+        self::$filesystem->remove(self::$workingDir);
+        self::$filesystem->mkdir(self::$workingDir, 0777);
+        $this->mergedConfig = [];
+    }
+
+    #[\Behat\Hook\AfterScenario]
+    public function afterScenario(): void
+    {
+        self::$filesystem->remove(self::$workingDir);
+    }
+
+    #[\Behat\Step\Given('a standard autoloader configured')]
+    public function standardAutoloaderConfigured(): void
+    {
+        $this->thereIsFile('vendor/autoload.php', sprintf(
+            <<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+$loader = require '%s';
+$loader->addPsr4('App\\Tests\\', __DIR__ . '/../tests/');
+
+return $loader;
+PHP,
+            __DIR__ . '/../../../vendor/autoload.php',
+        ));
+    }
+
+    #[\Behat\Step\Given('a fake Mink driver available')]
+    public function aFakeMinkDriverAvailable(): void
+    {
+        $this->thereIsFile('tests/FakeDriver.php', <<<'PHP'
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests;
+
+use Behat\Mink\Driver\CoreDriver;
+
+final class FakeDriver extends CoreDriver
+{
+    private string $currentUrl = '';
+
+    private int $statusCode = 200;
+
+    public function __construct(private readonly array $pages = [])
+    {
+    }
+
+    public function start(): void {}
+
+    public function isStarted(): bool
+    {
+        return true;
+    }
+
+    public function stop(): void {}
+
+    public function reset(): void
+    {
+        $this->currentUrl = '';
+        $this->statusCode = 200;
+    }
+
+    public function visit($url): void
+    {
+        $this->currentUrl = $url;
+        $path = parse_url($url, PHP_URL_PATH) ?? '/';
+        $this->statusCode = array_key_exists($path, $this->pages) ? 200 : 404;
+    }
+
+    public function getCurrentUrl(): string
+    {
+        return $this->currentUrl;
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    public function getContent(): string
+    {
+        $path = parse_url($this->currentUrl, PHP_URL_PATH) ?? '/';
+
+        return $this->pages[$path] ?? '';
+    }
+
+    public function find($xpath): array
+    {
+        $content = $this->getContent();
+        if ($content === '') {
+            return [];
+        }
+
+        $dom = new \DOMDocument();
+        @$dom->loadHTML($content);
+        $xpathObj = new \DOMXPath($dom);
+        $nodes = $xpathObj->query($xpath);
+
+        if ($nodes === false) {
+            return [];
+        }
+
+        $results = [];
+        foreach ($nodes as $i => $node) {
+            $results[] = sprintf('(%s)[%d]', $xpath, $i + 1);
+        }
+
+        return $results;
+    }
+
+    public function getHtml($xpath): string
+    {
+        return '';
+    }
+
+    public function getText($xpath): string
+    {
+        return '';
+    }
+
+    public function getAttribute($xpath, $name): ?string
+    {
+        return null;
+    }
+
+    public function setValue($xpath, $value): void {}
+
+    public function click($xpath): void {}
+
+    public function isSelected($xpath): bool
+    {
+        return false;
+    }
+
+    public function isChecked($xpath): bool
+    {
+        return false;
+    }
+
+    public function isVisible($xpath): bool
+    {
+        return false;
+    }
+
+    public function isDisabled($xpath): bool
+    {
+        return false;
+    }
+
+    public function getValue($xpath): string|bool|array|null
+    {
+        return null;
+    }
+}
+PHP);
+    }
+
+    #[\Behat\Step\Given('/^a Behat configuration containing(?: "([^"]+)"|:)$/')]
+    public function thereIsConfiguration(string $content): void
+    {
+        $this->mergedConfig = array_replace_recursive($this->mergedConfig, Yaml::parse($content));
+
+        self::$filesystem->dumpFile(
+            sprintf('%s/behat.dist.php', self::$workingDir),
+            sprintf(
+                "<?php\nreturn new \\Tests\\FriendsOfBehat\\PageObjectExtension\\Behat\\Config\\ArrayConfig(%s);\n",
+                var_export($this->mergedConfig, true),
+            ),
+        );
+    }
+
+    #[\Behat\Step\Given('/^a (?:.+ |)file "([^"]+)" containing(?: "([^"]+)"|:)$/')]
+    public function thereIsFile(string $file, string $content): string
+    {
+        $path = self::$workingDir . '/' . $file;
+
+        if (str_ends_with($file, '.php')) {
+            $content = $this->replaceAnnotationsWithAttributes($content);
+        }
+
+        self::$filesystem->dumpFile($path, $content);
+
+        return $path;
+    }
+
+    #[\Behat\Step\Given('/^a feature file containing(?: "([^"]+)"|:)$/')]
+    public function thereIsFeatureFile(string $content): void
+    {
+        $this->thereIsFile(sprintf('features/%s.feature', md5(uniqid('', true))), $content);
+    }
+
+    #[\Behat\Step\When('/^I run Behat$/')]
+    public function iRunBehat(): void
+    {
+        $executablePath = BEHAT_BIN_PATH;
+
+        $this->process = new Process(
+            [self::$phpBin, $executablePath, '--strict', '-vvv', '--no-interaction', '--lang=en'],
+            self::$workingDir,
+        );
+        $this->process->start();
+        $this->process->wait();
+    }
+
+    #[\Behat\Step\Then('/^it should pass$/')]
+    public function itShouldPass(): void
+    {
+        if (0 === $this->getProcessExitCode()) {
+            return;
+        }
+
+        throw new \DomainException(
+            'Behat was expecting to pass, but failed with the following output:' . \PHP_EOL . \PHP_EOL . $this->getProcessOutput(),
+        );
+    }
+
+    #[\Behat\Step\Then('/^it should pass with(?: "([^"]+)"|:)$/')]
+    public function itShouldPassWith(string $expectedOutput): void
+    {
+        $this->itShouldPass();
+        $this->assertOutputMatches($expectedOutput);
+    }
+
+    #[\Behat\Step\Then('/^it should fail$/')]
+    public function itShouldFail(): void
+    {
+        if (0 !== $this->getProcessExitCode()) {
+            return;
+        }
+
+        throw new \DomainException(
+            'Behat was expecting to fail, but passed with the following output:' . \PHP_EOL . \PHP_EOL . $this->getProcessOutput(),
+        );
+    }
+
+    #[\Behat\Step\Then('/^it should fail with(?: "([^"]+)"|:)$/')]
+    public function itShouldFailWith(string $expectedOutput): void
+    {
+        $this->itShouldFail();
+        $this->assertOutputMatches($expectedOutput);
+    }
+
+    #[\Behat\Step\Then('/^it should end with(?: "([^"]+)"|:)$/')]
+    public function itShouldEndWith(string $expectedOutput): void
+    {
+        $this->assertOutputMatches($expectedOutput);
+    }
+
+    private function assertOutputMatches(string $expectedOutput): void
+    {
+        $pattern = '/' . preg_quote($expectedOutput, '/') . '/sm';
+        $output = $this->getProcessOutput();
+
+        $result = preg_match($pattern, $output);
+        if (false === $result) {
+            throw new \InvalidArgumentException('Invalid pattern given: ' . $pattern);
+        }
+
+        if (0 === $result) {
+            throw new \DomainException(sprintf(
+                'Pattern "%s" does not match the following output:' . \PHP_EOL . \PHP_EOL . '%s',
+                $pattern,
+                $output,
+            ));
+        }
+    }
+
+    private function getProcessOutput(): string
+    {
+        $this->assertProcessIsAvailable();
+
+        return $this->process->getErrorOutput() . $this->process->getOutput();
+    }
+
+    private function getProcessExitCode(): int
+    {
+        $this->assertProcessIsAvailable();
+
+        return $this->process->getExitCode();
+    }
+
+    private function assertProcessIsAvailable(): void
+    {
+        if (null === $this->process) {
+            throw new \BadMethodCallException('Behat process cannot be found. Did you run it before making assertions?');
+        }
+    }
+
+    private function replaceAnnotationsWithAttributes(string $code): string
+    {
+        return (string) preg_replace_callback(
+            '/^( *)\/\*\*\s*@(Given|When|Then|BeforeScenario|AfterScenario|BeforeFeature|AfterFeature)(?:\s+(.+?))?\s*\*\/$/m',
+            static function (array $m): string {
+                $indent = $m[1];
+                $name = $m[2];
+                $arg = isset($m[3]) && $m[3] !== '' ? "('" . str_replace("'", "\\'", $m[3]) . "')" : '';
+                $ns = in_array($name, ['Given', 'When', 'Then'], true) ? 'Step' : 'Hook';
+
+                return "{$indent}#[\\Behat\\{$ns}\\{$name}{$arg}]";
+            },
+            $code,
+        );
+    }
+
+    private static function findPhpBinary(): string
+    {
+        $phpBinary = (new PhpExecutableFinder())->find();
+        if (false === $phpBinary) {
+            throw new \RuntimeException('Unable to find the PHP executable.');
+        }
+
+        return $phpBinary;
+    }
+}

--- a/tests/Behat/Context/TestContext.php
+++ b/tests/Behat/Context/TestContext.php
@@ -123,7 +123,7 @@ final class FakeDriver extends CoreDriver
         return $this->pages[$path] ?? '';
     }
 
-    public function find($xpath): array
+    protected function findElementXpaths($xpath): array
     {
         $content = $this->getContent();
         if ($content === '') {
@@ -181,11 +181,6 @@ final class FakeDriver extends CoreDriver
         return false;
     }
 
-    public function isDisabled($xpath): bool
-    {
-        return false;
-    }
-
     public function getValue($xpath): string|bool|array|null
     {
         return null;
@@ -213,7 +208,7 @@ PHP);
     {
         $path = self::$workingDir . '/' . $file;
 
-        if (str_ends_with($file, '.php')) {
+        if (str_ends_with($file, '.php') && str_contains($content, '* @')) {
             $content = $this->replaceAnnotationsWithAttributes($content);
         }
 
@@ -225,7 +220,7 @@ PHP);
     #[\Behat\Step\Given('/^a feature file containing(?: "([^"]+)"|:)$/')]
     public function thereIsFeatureFile(string $content): void
     {
-        $this->thereIsFile(sprintf('features/%s.feature', md5(uniqid('', true))), $content);
+        $this->thereIsFile(sprintf('features/%s.feature', uniqid('', true)), $content);
     }
 
     #[\Behat\Step\When('/^I run Behat$/')]
@@ -287,18 +282,12 @@ PHP);
 
     private function assertOutputMatches(string $expectedOutput): void
     {
-        $pattern = '/' . preg_quote($expectedOutput, '/') . '/sm';
         $output = $this->getProcessOutput();
 
-        $result = preg_match($pattern, $output);
-        if (false === $result) {
-            throw new \InvalidArgumentException('Invalid pattern given: ' . $pattern);
-        }
-
-        if (0 === $result) {
+        if (!preg_match('/' . preg_quote($expectedOutput, '/') . '/sm', $output)) {
             throw new \DomainException(sprintf(
-                'Pattern "%s" does not match the following output:' . \PHP_EOL . \PHP_EOL . '%s',
-                $pattern,
+                'Expected output to contain "%s", got:' . \PHP_EOL . \PHP_EOL . '%s',
+                $expectedOutput,
                 $output,
             ));
         }

--- a/tests/Behat/Context/TestContext.php
+++ b/tests/Behat/Context/TestContext.php
@@ -58,7 +58,7 @@ $loader->addPsr4('App\\Tests\\', __DIR__ . '/../tests/');
 
 return $loader;
 PHP,
-            __DIR__ . '/../../../vendor/autoload.php',
+            __DIR__.'/../../../vendor/autoload.php',
         ));
     }
 
@@ -206,7 +206,7 @@ PHP);
     #[\Behat\Step\Given('/^a (?:.+ |)file "([^"]+)" containing(?: "([^"]+)"|:)$/')]
     public function thereIsFile(string $file, string $content): string
     {
-        $path = self::$workingDir . '/' . $file;
+        $path = self::$workingDir.'/'.$file;
 
         if (str_ends_with($file, '.php') && str_contains($content, '* @')) {
             $content = $this->replaceAnnotationsWithAttributes($content);
@@ -243,9 +243,7 @@ PHP);
             return;
         }
 
-        throw new \DomainException(
-            'Behat was expecting to pass, but failed with the following output:' . \PHP_EOL . \PHP_EOL . $this->getProcessOutput(),
-        );
+        throw new \DomainException('Behat was expecting to pass, but failed with the following output:'.\PHP_EOL.\PHP_EOL.$this->getProcessOutput());
     }
 
     #[\Behat\Step\Then('/^it should pass with(?: "([^"]+)"|:)$/')]
@@ -262,9 +260,7 @@ PHP);
             return;
         }
 
-        throw new \DomainException(
-            'Behat was expecting to fail, but passed with the following output:' . \PHP_EOL . \PHP_EOL . $this->getProcessOutput(),
-        );
+        throw new \DomainException('Behat was expecting to fail, but passed with the following output:'.\PHP_EOL.\PHP_EOL.$this->getProcessOutput());
     }
 
     #[\Behat\Step\Then('/^it should fail with(?: "([^"]+)"|:)$/')]
@@ -284,34 +280,30 @@ PHP);
     {
         $output = $this->getProcessOutput();
 
-        if (!preg_match('/' . preg_quote($expectedOutput, '/') . '/sm', $output)) {
-            throw new \DomainException(sprintf(
-                'Expected output to contain "%s", got:' . \PHP_EOL . \PHP_EOL . '%s',
-                $expectedOutput,
-                $output,
-            ));
+        if (!preg_match('/'.preg_quote($expectedOutput, '/').'/sm', $output)) {
+            throw new \DomainException(sprintf('Expected output to contain "%s", got:'.\PHP_EOL.\PHP_EOL.'%s', $expectedOutput, $output));
         }
     }
 
-    private function getProcessOutput(): string
-    {
-        $this->assertProcessIsAvailable();
-
-        return $this->process->getErrorOutput() . $this->process->getOutput();
-    }
-
-    private function getProcessExitCode(): int
-    {
-        $this->assertProcessIsAvailable();
-
-        return $this->process->getExitCode();
-    }
-
-    private function assertProcessIsAvailable(): void
+    private function getProcess(): Process
     {
         if (null === $this->process) {
             throw new \BadMethodCallException('Behat process cannot be found. Did you run it before making assertions?');
         }
+
+        return $this->process;
+    }
+
+    private function getProcessOutput(): string
+    {
+        $process = $this->getProcess();
+
+        return $process->getErrorOutput().$process->getOutput();
+    }
+
+    private function getProcessExitCode(): int
+    {
+        return (int) $this->getProcess()->getExitCode();
     }
 
     private function replaceAnnotationsWithAttributes(string $code): string
@@ -321,7 +313,7 @@ PHP);
             static function (array $m): string {
                 $indent = $m[1];
                 $name = $m[2];
-                $arg = isset($m[3]) && $m[3] !== '' ? "('" . str_replace("'", "\\'", $m[3]) . "')" : '';
+                $arg = isset($m[3]) && '' !== $m[3] ? "('".str_replace("'", "\\'", $m[3])."')" : '';
                 $ns = in_array($name, ['Given', 'When', 'Then'], true) ? 'Step' : 'Hook';
 
                 return "{$indent}#[\\Behat\\{$ns}\\{$name}{$arg}]";


### PR DESCRIPTION
## Summary

- **Expand CI matrix** with correct version constraints:
  - Stable: PHP 8.3–8.5 × Symfony 7.4 × Behat 3.31
  - Experimental (`continue-on-error: true`): Behat 4.x-dev × Symfony 7.4/8.0/8.1 — PHP 8.3 excluded from Symfony 8.x rows (Symfony 8 requires PHP ≥8.4; Behat 3 cannot install alongside Symfony 8)
- **Add `bin/lock-symfony-version.sh` and `bin/lock-behat-version.sh`** for CI version pinning via safe `jq … > tmp && mv` pattern
- **Add PHPStan** (level 8, baseline for existing issues, `treatPhpDocTypesAsCertain: false`, bootstrap defining `BEHAT_BIN_PATH`) and **php-cs-fixer** (`@Symfony` ruleset) with dedicated CI jobs
- **Widen `composer.json`**: `behat/behat ^3.31 || 4.x-dev`, all `symfony/*` to `^7.4 || ^8.0`, added `symfony/routing` (needed for static analysis of `SymfonyPage`), `minimum-stability: dev` + `prefer-stable: true`

## Source simplifications

- **Fix dead `array_map`** in `Page::resolveParameters` and `Element::resolveParameters` — result was silently discarded; parameter substitution never applied for array-style selectors
- **Extract `SymfonyPage::matchCurrentRoute()`** — removes verbatim-duplicated `parse_url → preg_replace → router->match` block shared by `verifyRoute()` and `verifyUrl()`
- **Replace `assertProcessIsAvailable()`** with `getProcess(): Process` (non-nullable return, PHPStan-friendly) in `TestContext`
- **`parse_url($url, PHP_URL_PATH) ?? '/'`** — null-safe path extraction replacing `parse_url($url)['path']`
- Drop unused catch variable bindings; `array_key_first()` over `key()`; remove redundant `@var array` docblock and `@param` docblocks already covered by union types

🤖 Generated with [Claude Code](https://claude.ai/code)